### PR TITLE
CLOUD-295 add custom startup script to set referrer policy header

### DIFF
--- a/startup-scripts/add_referrer_policy_header.cli
+++ b/startup-scripts/add_referrer_policy_header.cli
@@ -1,0 +1,2 @@
+/subsystem=undertow/configuration=filter/response-header=referrer-policy:add(header-name=Referrer-Policy,header-value=strict-origin-when-cross-origin)
+/subsystem=undertow/server=default-server/host=default-host/filter-ref=referrer-policy:add


### PR DESCRIPTION
Add custom script that adds HTTP header "Referrer-Policy". On v4.8 this script needs to be enabled via property `keycloak.cli.custom` provided by our chart. On version 5 and above custom scripts will be  supported by the docker image itself and do not need any special chart support.